### PR TITLE
Bundle kadena-graph and trim closure

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
         };
     in {
       packages = {
-        kadena-graph = graph.kadena-graph;
+        inherit (graph) kadena-graph kadena-graph-bundle;
       };
       apps = {
         update-node-packages = {

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
         };
     in {
       packages = {
-        inherit (graph) kadena-graph kadena-graph-bundle;
+        inherit (graph) kadena-graph kadena-graph-unbundled;
       };
       apps = {
         update-node-packages = {

--- a/pkgs/graph/default.nix
+++ b/pkgs/graph/default.nix
@@ -37,8 +37,8 @@ let
     GRAPH="kadena-graph/lib/node_modules/@kadena/graph/"
     for dir in db devnet utils services; do ln -s ../src/$dir "$GRAPH/node_modules/@$dir"; done
 
-    ( cd "$GRAPH" && \
-      esbuild dist/index.d.ts --bundle --outfile=$out/bin/kadena-graph --format=cjs --platform=node \
+    ( cd "$GRAPH" &&
+      esbuild dist/index.d.ts --bundle --outfile=$out/bin/kadena-graph --format=cjs --platform=node
     )
 
     remove-references-to -t ${kadena-graph} $out/bin/kadena-graph

--- a/pkgs/graph/default.nix
+++ b/pkgs/graph/default.nix
@@ -1,6 +1,7 @@
 { pkgs ? import <nixpkgs> {inherit system;}
 , system ? builtins.currentSystem
-, nodePackages ? import ../nodePackages { inherit pkgs system; }
+, nodejs ? pkgs.nodejs
+, nodePackages ? import ../nodePackages { inherit pkgs system nodejs; }
 }:
 let
   prisma-engines = pkgs.prisma-engines;
@@ -20,6 +21,30 @@ let
         --set PRISMA_FMT_BINARY "${prisma-engines}/bin/prisma-fmt"
     '';
   });
+  kadena-graph-bundle = pkgs.runCommand "kadena-graph" {
+    buildInputs = [pkgs.esbuild pkgs.makeWrapper pkgs.removeReferencesTo];
+  } ''
+    mkdir -p $out
+    cp -r ${kadena-graph} drv
+    chmod -R +w drv
+    cd drv/lib/node_modules/@kadena/graph/node_modules/
+    ln -s ../src/db @db
+    ln -s ../src/devnet/ @devnet
+    ln -s ../src/utils/ @utils
+    ln -s ../src/services/ @services
+    cd ..
+    esbuild ./dist/index.d.ts --bundle --outfile=$out/bin/kadena-graph --format=cjs --platform=node
+
+    remove-references-to -t ${kadena-graph} $out/bin/kadena-graph
+
+    wrapProgram $out/bin/kadena-graph \
+      --set PRISMA_SCHEMA_ENGINE_BINARY "${prisma-engines}/bin/schema-engine" \
+      --set PRISMA_QUERY_ENGINE_BINARY "${prisma-engines}/bin/query-engine" \
+      --set PRISMA_QUERY_ENGINE_LIBRARY "${prisma-engines}/lib/libquery_engine.node" \
+      --set PRISMA_INTROSPECTION_ENGINE_BINARY "${prisma-engines}/bin/introspection-engine" \
+      --set PRISMA_FMT_BINARY "${prisma-engines}/bin/prisma-fmt" \
+      --prefix PATH : ${pkgs.nodejs-slim}/bin
+  '';
 in {
-  inherit nodePackages kadena-graph;
+  inherit nodePackages kadena-graph kadena-graph-bundle;
 }

--- a/pkgs/graph/default.nix
+++ b/pkgs/graph/default.nix
@@ -35,7 +35,7 @@ let
     cd ..
     esbuild ./dist/index.d.ts --bundle --outfile=$out/bin/kadena-graph --format=cjs --platform=node
 
-    prisma_client=lib/node_modules/@kadena/graph/node_modules/@prisma/client
+    prisma_client=lib/node_modules/@kadena/graph/node_modules/@prisma
     mkdir -p $out/$prisma_client
     cp -r ${kadena-graph}/$prisma_client/* $out/$prisma_client
     substituteInPlace $out/bin/kadena-graph \

--- a/pkgs/graph/default.nix
+++ b/pkgs/graph/default.nix
@@ -35,7 +35,11 @@ let
     cd ..
     esbuild ./dist/index.d.ts --bundle --outfile=$out/bin/kadena-graph --format=cjs --platform=node
 
-    remove-references-to -t ${kadena-graph} $out/bin/kadena-graph
+    prisma_client=lib/node_modules/@kadena/graph/node_modules/@prisma/client
+    mkdir -p $out/$prisma_client
+    cp -r ${kadena-graph}/$prisma_client/* $out/$prisma_client
+    substituteInPlace $out/bin/kadena-graph \
+      --replace ${kadena-graph}/$prisma_client $out/$prisma_client
 
     wrapProgram $out/bin/kadena-graph \
       --set PRISMA_SCHEMA_ENGINE_BINARY "${prisma-engines}/bin/schema-engine" \

--- a/pkgs/graph/default.nix
+++ b/pkgs/graph/default.nix
@@ -28,9 +28,9 @@ let
   '';
 
   kadena-graph = pkgs.stdenv.mkDerivation rec {
+    inherit (kadena-graph-unbundled) version packageName;
     buildInputs = [pkgs.esbuild pkgs.makeWrapper pkgs.removeReferencesTo];
     name = "kadena-graph-${version}";
-    version = kadena-graph-unbundled.version;
     enableParallelBuilding = true;
     passAsFile = [ "buildCommand" ];
     buildCommand = ''

--- a/pkgs/graph/default.nix
+++ b/pkgs/graph/default.nix
@@ -5,6 +5,12 @@
 }:
 let
   prisma-engines = pkgs.prisma-engines;
+  prisma-slim = pkgs.runCommand "prisma-slim" {} ''
+    mkdir -p $out/bin
+
+    cp -r ${prisma-engines}/lib $out/lib
+    cp -r ${prisma-engines}/bin/query-engine $out/bin
+  '';
   kadena-graph = nodePackages."@kadena/graph".overrideDerivation (attrs: {
     buildInputs = attrs.buildInputs ++ [pkgs.prisma-engines pkgs.makeWrapper];
     PRISMA_SCHEMA_ENGINE_BINARY="${prisma-engines}/bin/schema-engine";
@@ -41,11 +47,8 @@ let
       --replace "/usr/bin/env node" ${pkgs.nodejs-slim}/bin/node
 
     wrapProgram $out/bin/kadena-graph \
-      --set PRISMA_SCHEMA_ENGINE_BINARY "${prisma-engines}/bin/schema-engine" \
-      --set PRISMA_QUERY_ENGINE_BINARY "${prisma-engines}/bin/query-engine" \
-      --set PRISMA_QUERY_ENGINE_LIBRARY "${prisma-engines}/lib/libquery_engine.node" \
-      --set PRISMA_INTROSPECTION_ENGINE_BINARY "${prisma-engines}/bin/introspection-engine" \
-      --set PRISMA_FMT_BINARY "${prisma-engines}/bin/prisma-fmt"
+      --set PRISMA_QUERY_ENGINE_BINARY "${prisma-slim}/bin/query-engine" \
+      --set PRISMA_QUERY_ENGINE_LIBRARY "${prisma-slim}/lib/libquery_engine.node" \
 
     mkdir -p $out/lib/node_modules/@kadena/graph/
     cp -r ${kadena-graph}/lib/node_modules/@kadena/graph/cwd-extra-migrations $out/lib/node_modules/@kadena/graph/

--- a/pkgs/graph/default.nix
+++ b/pkgs/graph/default.nix
@@ -6,10 +6,8 @@
 let
   prisma-engines = pkgs.prisma-engines;
   prisma-slim = pkgs.runCommand "prisma-slim" {} ''
-    mkdir -p $out/bin
-
+    mkdir -p $out
     cp -r ${prisma-engines}/lib $out/lib
-    cp -r ${prisma-engines}/bin/query-engine $out/bin
   '';
   kadena-graph = nodePackages."@kadena/graph".overrideDerivation (attrs: {
     buildInputs = attrs.buildInputs ++ [pkgs.prisma-engines pkgs.makeWrapper];
@@ -47,7 +45,6 @@ let
       --replace "/usr/bin/env node" ${pkgs.nodejs-slim}/bin/node
 
     wrapProgram $out/bin/kadena-graph \
-      --set PRISMA_QUERY_ENGINE_BINARY "${prisma-slim}/bin/query-engine" \
       --set PRISMA_QUERY_ENGINE_LIBRARY "${prisma-slim}/lib/libquery_engine.node" \
 
     mkdir -p $out/lib/node_modules/@kadena/graph/

--- a/pkgs/graph/default.nix
+++ b/pkgs/graph/default.nix
@@ -42,7 +42,7 @@ let
       for dir in db devnet utils services; do ln -s ../src/$dir "$GRAPH/node_modules/@$dir"; done
 
       ( cd "$GRAPH" &&
-        esbuild dist/index.d.ts --bundle --outfile=$out/bin/kadena-graph --format=cjs --platform=node
+        esbuild dist/index.js --bundle --outfile=$out/bin/kadena-graph --format=cjs --platform=node
       )
 
       remove-references-to -t ${kadena-graph-unbundled} $out/bin/kadena-graph

--- a/pkgs/graph/default.nix
+++ b/pkgs/graph/default.nix
@@ -35,19 +35,17 @@ let
     cd ..
     esbuild ./dist/index.d.ts --bundle --outfile=$out/bin/kadena-graph --format=cjs --platform=node
 
-    prisma_client=lib/node_modules/@kadena/graph/node_modules/@prisma
-    mkdir -p $out/$prisma_client
-    cp -r ${kadena-graph}/$prisma_client/* $out/$prisma_client
+    remove-references-to -t ${kadena-graph} $out/bin/kadena-graph
+
     substituteInPlace $out/bin/kadena-graph \
-      --replace ${kadena-graph}/$prisma_client $out/$prisma_client
+      --replace "/usr/bin/env node" ${pkgs.nodejs-slim}/bin/node
 
     wrapProgram $out/bin/kadena-graph \
       --set PRISMA_SCHEMA_ENGINE_BINARY "${prisma-engines}/bin/schema-engine" \
       --set PRISMA_QUERY_ENGINE_BINARY "${prisma-engines}/bin/query-engine" \
       --set PRISMA_QUERY_ENGINE_LIBRARY "${prisma-engines}/lib/libquery_engine.node" \
       --set PRISMA_INTROSPECTION_ENGINE_BINARY "${prisma-engines}/bin/introspection-engine" \
-      --set PRISMA_FMT_BINARY "${prisma-engines}/bin/prisma-fmt" \
-      --prefix PATH : ${pkgs.nodejs-slim}/bin
+      --set PRISMA_FMT_BINARY "${prisma-engines}/bin/prisma-fmt"
 
     mkdir -p $out/lib/node_modules/@kadena/graph/
     cp -r ${kadena-graph}/lib/node_modules/@kadena/graph/cwd-extra-migrations $out/lib/node_modules/@kadena/graph/

--- a/pkgs/graph/default.nix
+++ b/pkgs/graph/default.nix
@@ -52,6 +52,7 @@ let
     MIGRATIONS=lib/node_modules/@kadena/graph/cwd-extra-migrations
     mkdir -p $out/$MIGRATIONS
     cp -r ${kadena-graph}/$MIGRATIONS/* $out/$MIGRATIONS
+    ln -s $MIGRATIONS $out/cwd-extra-migrations
   '';
 in {
   inherit nodePackages kadena-graph kadena-graph-bundle;

--- a/pkgs/graph/default.nix
+++ b/pkgs/graph/default.nix
@@ -44,6 +44,9 @@ let
       --set PRISMA_INTROSPECTION_ENGINE_BINARY "${prisma-engines}/bin/introspection-engine" \
       --set PRISMA_FMT_BINARY "${prisma-engines}/bin/prisma-fmt" \
       --prefix PATH : ${pkgs.nodejs-slim}/bin
+
+    mkdir -p $out/lib/node_modules/@kadena/graph/
+    cp -r ${kadena-graph}/lib/node_modules/@kadena/graph/cwd-extra-migrations $out/lib/node_modules/@kadena/graph/
   '';
 in {
   inherit nodePackages kadena-graph kadena-graph-bundle;


### PR DESCRIPTION
This PR adds a post-processing step to the existing `kadena-graph` output of this flake and bundles the `graph` package down to a single .js file of size 5MB (down from the previous ~200MB). It also removes the unnecessary `prisma` binaries from its environment and further reduces its closure. With these changes in place, the extra closure required for the `kadena-graph` package on top of a Nix environment that already has `nodejs` goes down to 20MB (used to be ~250MB).