### PR TITLE
Add a nix build and cache action

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,43 @@
+name: Build and cache with Nix
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+    - '**'
+
+jobs:
+  build-and-cache:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 740
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, macos-m1]
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Set up Nix with caching
+      uses: kadena-io/setup-nix-with-cache/by-root@v3.1
+      with:
+        cache_url: s3://nixcache.chainweb.com?region=us-east-1
+        signing_private_key: ${{ secrets.NIX_CACHE_PRIVATE_KEY }}
+        additional_experimental_features: recursive-nix
+
+
+    - name: Set up AWS credentials
+      uses: aws-actions/configure-aws-credentials@v2
+      with:
+        aws-access-key-id: ${{ secrets.NIX_CACHE_AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.NIX_CACHE_AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-east-1
+
+    - name: Give root user AWS credentials
+      uses: kadena-io/setup-nix-with-cache/copy-root-aws-credentials@v3.1
+
+    - name: Build and cache artifacts
+      run: |
+        echo Building the packages
+        nix build .#kadena-graph --log-lines 500 --show-trace
+        nix build .#kadena-cli --log-lines 500 --show-trace


### PR DESCRIPTION
Currently the action builds `kadena-graph` and `kadena-cli`